### PR TITLE
Removed mod specs from app.src

### DIFF
--- a/src/emagick.app.src
+++ b/src/emagick.app.src
@@ -29,6 +29,5 @@
   {modules, [emagick]},
   {registered, []},
   {applications, [kernel,
-                  stdlib]},
-  {mod, {emagick, []}}
+                  stdlib]}
  ]}.


### PR DESCRIPTION
The emagick module do not implement the application behaviour, so when starting it, the application:start will fail.
This patch makes emagick into a pure library.
