### PR TITLE
UUID library upgraded to 1.7.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
 
 {deps, [
-    {uuid, ".*", {git, "git://github.com/okeuday/uuid.git", {tag, "v1.5.0"}}}
+    {uuid, ".*", {git, "git://github.com/okeuday/uuid.git", {tag, "v1.7.3"}}}
     ]}.
 
 {erl_opts, [


### PR DESCRIPTION
We have moved to Erlang 20 and we needed to upgrade uuid library to 1.7.3.

No problems detected after some days in production.
